### PR TITLE
Fix missing dot before extension.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var uuid = require('uuid');
 var Vinyl = require('vinyl');
 
 module.exports.file = function (buf, name) {
-	var ext = fileType(buf) ? fileType(buf).ext : null;
+	var ext = fileType(buf) ? '.' + fileType(buf).ext : null;
 
 	return new Vinyl({
 		contents: buf,


### PR DESCRIPTION
node-file-type returns only extension without dot.
So resulting filename is like f61c1803-6bd3-4192-93f5-1f84ad1a19c3jpg
